### PR TITLE
yaml support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ MIT. See LICENSE
 
 ## Features
 
-* Configure containers in clear json syntax
+* Configure containers in clear json or yml syntax
 * Automatically starts linked containers
 * Mount volumes, forward ports
 * Supports building images using a Dockerfile template
 * Supports before/after hooks for container startup
-* Supports including other pig.json files 
+* Supports including other pig files 
 
 ## Installation
 
@@ -247,6 +247,26 @@ Not going well? Set `VERBOSE=true` to get some output.
 
 Having problems with hanging builds, or in general with pseudo-ttys? Use `NONINTERACTIVE=true` to start containers without `-it`
 
+## using YAML instead
+
+The pig.json file shown above can also be written as pig.yml:
+
+    db:
+        name: my-project-mongo
+        image: mongo:2.6.4
+        daemon: true
+        
+    myapp:
+        name: my-project-app
+        image: mongo:2.6.4
+        command:
+            - bash
+        links:
+            - db
+    
+    
+
+    
 ## Why not just use fig?
 
 I can't speak for you, but my reasons for not using fig after trying it out were:

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,4 +1,5 @@
-var errors = require('./errors')
+var errors = require('./errors'),
+        fs = require('fs')
 
 var usage = "Usage: pig COMMAND NAME [& args]\n\n" +
             "Commands:\n" +
@@ -50,8 +51,17 @@ function handleError(err) {
     }
 }
 
+function loadConfiguration(){
+  if (fs.existsSync('pig.json'))
+    return require('./config').fromFile('pig.json')
+
+  if (fs.existsSync('pig.yml'))
+    return require('./config').fromFile('pig.yml')
+}
+
+
 function main(args, callback) {
-    var config = require('./config').fromFile('pig')
+    var config = loadConfiguration()
     var commands = require('./commands')(config, args.options)
 
     switch (args.command) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -32,7 +32,7 @@ function getContainer(config, args) {
 
     var container = config[args.name]
     if (container) {
-        return container 
+        return container
     } else {
         throw new errors.PigError("Container '" + args.name + "' not found")
     }
@@ -40,7 +40,7 @@ function getContainer(config, args) {
 
 function handleError(err) {
     if (err instanceof errors.ConfigError) {
-        process.stderr.write('error in pig.json: ' + err.message + '\n')
+        process.stderr.write('error in pig file: ' + err.message + '\n')
         process.exit(1)
     } else if (err instanceof errors.PigError) {
         process.stderr.write('error: ' + err.message + '\n')
@@ -51,7 +51,7 @@ function handleError(err) {
 }
 
 function main(args, callback) {
-    var config = require('./config').fromFile('pig.json')
+    var config = require('./config').fromFile('pig')
     var commands = require('./commands')(config, args.options)
 
     switch (args.command) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,12 +5,14 @@ errors = require('./errors'),
   yaml = require('js-yaml')
 
 module.exports.fromFile = function(file) {
-    if (fs.existsSync(file + ".json")) {
-      config = fromJsonFile(file + '.json');
-    } else if (fs.existsSync(file + ".yml")) {
-      config = fromYamlFile(file + '.yml');
+    var config = null
+
+    if (path.extname(file) === '.json') {
+      config = fromJsonFile(file);
+    } else if (path.extname(file) === '.yml') {
+      config = fromYamlFile(file);
     } else {
-      throw new errors.ConfigError(file + '.(json|yml) not found')
+      throw new errors.ConfigError('Unknown file format: ' + file)
     }
 
     return resolveIncludes(config)
@@ -28,7 +30,7 @@ function fromYamlFile(file){
   try {
       return yaml.safeLoad(fs.readFileSync(file))
   } catch (err) {
-      throw new errors.ConfigError('Invalid JSON:\n' + err.stack)
+      throw new errors.ConfigError('Invalid Yaml:\n' + err.stack)
   }
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,23 +1,37 @@
 var fs = require('fs'),
 errors = require('./errors'),
      _ = require('lodash'),
-  path = require('path')
+  path = require('path'),
+  yaml = require('js-yaml')
 
 module.exports.fromFile = function(file) {
-    if (!fs.existsSync(file)) {
-        throw new errors.ConfigError(file + ' not found')
+    if (fs.existsSync(file + ".json")) {
+      config = fromJsonFile(file + '.json');
+    } else if (fs.existsSync(file + ".yml")) {
+      config = fromYamlFile(file + '.yml');
+    } else {
+      throw new errors.ConfigError(file + '.(json|yml) not found')
     }
-
-    var config
-    try {
-        config = JSON.parse(fs.readFileSync(file))
-    } catch (err) {
-        throw new errors.ConfigError('Invalid JSON:\n' + err.stack)
-    }
-
 
     return resolveIncludes(config)
 }
+
+function fromJsonFile(file){
+  try {
+      return JSON.parse(fs.readFileSync(file))
+  } catch (err) {
+      throw new errors.ConfigError('Invalid JSON:\n' + err.stack)
+  }
+}
+
+function fromYamlFile(file){
+  try {
+      return yaml.safeLoad(fs.readFileSync(file))
+  } catch (err) {
+      throw new errors.ConfigError('Invalid JSON:\n' + err.stack)
+  }
+}
+
 
 function createPrefixer(prefix) {
     return function(name) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Mikko Nylén",
   "dependencies": {
     "async": "^0.9.0",
+    "js-yaml": "^3.2.7",
     "lodash": "^2.4.1"
   },
   "devDependencies": {

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -12,7 +12,7 @@ describe('config', function() {
         it('adds containers from path to the root configuration using prefix', function() {
             process.chdir('test/include')
 
-            expect(config.fromFile('pig.json')).to.eql({
+            expect(config.fromFile('pig')).to.eql({
                 "prefix/fileserver":{
                     "name":"test-fileserver",
                     "image":"python",

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -2,6 +2,31 @@ var config = require('../lib/config'),
       path = require('path'),
     expect = require('chai').expect
 
+function getExpectedData(){
+    return {
+      "prefix/fileserver":{
+          "name":"test-fileserver",
+          "image":"python",
+          "daemon":true,
+          "command":["python", "-mhttp.server", "8080"],
+          "workdir":"/data",
+          "volumes":{
+              "../../data1":"/data"
+          },
+          "pigdir":path.join(process.cwd(), 'another')
+      },
+
+      "prefix/container":{
+          "name":"test-container",
+          "build":".",
+          "links":["prefix/fileserver"],
+          "volumesFrom":["prefix/fileserver"],
+          "pigdir":path.join(process.cwd(), 'another')
+      }
+    };
+};
+
+
 describe('config', function() {
     var mochaWorkingDirectory = process.cwd()
     afterEach(function() {
@@ -9,30 +34,13 @@ describe('config', function() {
     })
 
     describe('with includes', function() {
-        it('adds containers from path to the root configuration using prefix', function() {
+        it('adds containers from path to the root configuration using prefix in json', function() {
             process.chdir('test/include')
-
-            expect(config.fromFile('pig')).to.eql({
-                "prefix/fileserver":{
-                    "name":"test-fileserver",
-                    "image":"python",
-                    "daemon":true,
-                    "command":["python", "-mhttp.server", "8080"],
-                    "workdir":"/data",
-                    "volumes":{
-                        "../../data1":"/data"
-                    },
-                    "pigdir":path.join(process.cwd(), 'another')
-                },
-
-                "prefix/container":{
-                    "name":"test-container",
-                    "build":".",
-                    "links":["prefix/fileserver"],
-                    "volumesFrom":["prefix/fileserver"],
-                    "pigdir":path.join(process.cwd(), 'another')
-                }
-            })
+            expect(config.fromFile('pig.json')).to.eql(getExpectedData())
+        })
+        it('adds containers from path to the root configuration using prefix in yml', function() {
+            process.chdir('test/include-yml')
+            expect(config.fromFile('pig.yml')).to.eql(getExpectedData())
         })
     })
 })

--- a/test/include-yml/another/Dockerfile
+++ b/test/include-yml/another/Dockerfile
@@ -1,0 +1,6 @@
+FROM python
+
+ADD ./start.sh /start.sh
+RUN chmod +x /start.sh
+
+CMD ["/start.sh"]

--- a/test/include-yml/another/pig.yml
+++ b/test/include-yml/another/pig.yml
@@ -1,0 +1,18 @@
+fileserver: 
+  name: "test-fileserver"
+  image: "python"
+  daemon: true
+  command: 
+    - "python"
+    - "-mhttp.server"
+    - "8080"
+  workdir: "/data"
+  volumes: 
+    ../../data1: "/data"
+container: 
+  name: "test-container"
+  build: "."
+  links: 
+    - "fileserver"
+  volumesFrom: 
+    - "fileserver"

--- a/test/include-yml/another/start.sh
+++ b/test/include-yml/another/start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+sleep 1
+from_fileserver=$(curl fileserver:8080/lorem.txt)
+from_volume=$(cat /data/lorem.txt)
+
+echo "fileserver: ${from_fileserver}"
+echo "volume: ${from_volume}"

--- a/test/include-yml/pig.yml
+++ b/test/include-yml/pig.yml
@@ -1,0 +1,2 @@
+include:
+    another/pig.yml: "prefix"

--- a/test/include/pig.json
+++ b/test/include/pig.json
@@ -1,5 +1,5 @@
 {
   "include":{
-    "another/pig.json":"prefix"
+    "another/pig":"prefix"
   }
 }

--- a/test/include/pig.json
+++ b/test/include/pig.json
@@ -1,5 +1,5 @@
 {
   "include":{
-    "another/pig":"prefix"
+    "another/pig.json":"prefix"
   }
 }

--- a/test/start-included-test.js
+++ b/test/start-included-test.js
@@ -11,11 +11,11 @@ describe('starting containers included from another pig.json', function() {
     before(function(done) {
         process.chdir('test/include')
 
-        var config = require('../lib/config').fromFile('pig.json')
+        var config = require('../lib/config').fromFile('pig')
         helpers.commands(config).start(config['prefix/container'], [], { recreate: true }, done)
     })
 
-    it('chdirs to included pig.json path and starts the container', function(done) {
+    it('chdirs to included pig path and starts the container', function(done) {
         helpers.logsOutput('test-container', function(stdout) {
             expect(stdout).to.contain('fileserver: lorem ipsum dolor sit amet\n')
             expect(stdout).to.contain('volume: lorem ipsum dolor sit amet\n')


### PR DESCRIPTION
i added yaml support to optionaly use pig.yml instead of pig.json, you may want to add this as a feature, if you want to...i could not thorougly test it because i am working with windows docker-client (which, due to some minor incompatibilities, failed the mocha tests) but a test pig.yml could be read and docker-container was started, so i guess, it works :)