### PR TITLE
Add option to use existing container instead of re-creating it every "pig up/start"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,17 @@ And use `pig start mongoshell` whenever you need mongo shell access.
 
 ## Command reference
 
-* `start CONTAINER [args]` - starts container,  passing `args` to it's command 
+* `start [-R|--no-recreate] CONTAINER [args]` - starts container,  passing `args` to it's command 
 * `stop CONTAINER` - stops container
 * `bash CONTAINER` - executes a bash inside running container
 * `logs CONTAINER [opts]` - show `docker logs` output for container with the given `opts` (`-t` for tail, `-f` for follow, anything `docker logs` accepts)
 * `inspect CONTAINER` - show `docker inspect` output for container
-* `up` - start all daemons
+* `up [-R|--no-recreate]` - start all daemons
 * `down` - stop all daemons
+
+The default behaviour is that containers are re-created every time when `start` or `up` command is executed.
+If you want to prevent this behaviour and start existing container instead, add either `-R` or 
+`--no-recreate` flag to your `start`/`up` command.
 
 ## Basic configuration properties
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ And use `pig start mongoshell` whenever you need mongo shell access.
 
 * `start [-R|--no-recreate] CONTAINER [args]` - starts container,  passing `args` to it's command 
 * `stop CONTAINER` - stops container
+* `rm CONTAINER` - removes container
 * `bash CONTAINER` - executes a bash inside running container
 * `logs CONTAINER [opts]` - show `docker logs` output for container with the given `opts` (`-t` for tail, `-f` for follow, anything `docker logs` accepts)
 * `inspect CONTAINER` - show `docker inspect` output for container

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -74,7 +74,7 @@ function main(args, callback) {
             break
 
         case "stop":
-            commands.stop(getContainer(config, args), callback)
+            commands.stop(getContainer(config, null, args), callback)
             break
 
         case "bash":

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,6 +6,7 @@ var usage = "Usage: pig COMMAND NAME [& args]\n\n" +
             "Commands:\n" +
             "  start   Start container\n" +
             "  stop    Stop container\n" +
+            "  rm      Remove container\n" +
             "  logs    Show docker logs output for container (use -f for follow, -t for tail)\n" +
             "  inspect Show docker inspect output for container\n" +
             "  up      Start all daemons from pig.json\n" +
@@ -77,6 +78,10 @@ function main(args, callback) {
 
         case "stop":
             commands.stop(getContainer(config, args), null, callback)
+            break
+
+      case "rm":
+            commands.stop(getContainer(config, args), {removeStopped: true}, callback)
             break
 
         case "bash":

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -77,11 +77,11 @@ function main(args, callback) {
             break
 
         case "stop":
-            commands.stop(getContainer(config, args), null, callback)
+            commands.stop(getContainer(config, args), callback)
             break
 
       case "rm":
-            commands.stop(getContainer(config, args), {removeStopped: true}, callback)
+            commands.remove(getContainer(config, args), callback)
             break
 
         case "bash":

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -76,7 +76,7 @@ function main(args, callback) {
             break
 
         case "stop":
-            commands.stop(getContainer(config, null, args), callback)
+            commands.stop(getContainer(config, args), null, callback)
             break
 
         case "bash":

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,6 @@
 var errors = require('./errors'),
-        fs = require('fs')
+        fs = require('fs'),
+         _ = require('lodash')
 
 var usage = "Usage: pig COMMAND NAME [& args]\n\n" +
             "Commands:\n" +
@@ -13,8 +14,9 @@ var usage = "Usage: pig COMMAND NAME [& args]\n\n" +
 
 function parseArgs(args) {
     var command     = args[0]
-    var name        = args[1]
-    var remainder  = args.slice(2)
+    var recreate    = _.contains(['--no-recreate', '-R'], args[1]) == false
+    var name        = recreate ? args[1] : args[2]
+    var remainder   = args.slice(recreate ? 2 : 3)
     var interactive = !(process.env["NONINTERACTIVE"] === 'true')
     var verbose     = process.env["VERBOSE"] === 'true'
 
@@ -22,7 +24,7 @@ function parseArgs(args) {
         command: command,
         name: name,
         remainder: remainder,
-        options: { interactive: interactive, verbose: verbose },
+        options: { interactive: interactive, verbose: verbose, recreate: recreate },
     }
 }
 
@@ -70,7 +72,7 @@ function main(args, callback) {
 
     switch (args.command) {
         case "start":
-            commands.start(getContainer(config, args), args.remainder, { recreate: true }, callback)
+            commands.start(getContainer(config, args), args.remainder, { recreate: args.options.recreate }, callback)
             break
 
         case "stop":
@@ -82,7 +84,7 @@ function main(args, callback) {
             break
 
         case "up":
-            commands.startDaemons(callback)
+            commands.startDaemons({ recreate: args.options.recreate }, callback)
             break
 
         case "down":

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -17,6 +17,18 @@ module.exports = function(containers, options) {
         ], { stdio: 'inherit' })
     }
 
+    function startContainer(container, commandArgs, startOptions, done) {
+        start(container, commandArgs, startOptions, done)
+    }
+
+    function stopContainer(container, done) {
+        stop(container, {removeStopped: false}, done)
+    }
+
+    function removeContainer(container, done) {
+        stop(container, {removeStopped: true}, done)
+    }
+
     function startDaemons(startOptions, done) {
         done = done || _.noop
 
@@ -46,9 +58,10 @@ module.exports = function(containers, options) {
         })
     }
 
-    return { 
-        start: start,
-        stop: stop,
+    return {
+        start: startContainer,
+        stop: stopContainer,
+        remove: removeContainer,
         bash: bash,
         startDaemons: startDaemons,
         stopDaemons: stopDaemons,

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -31,7 +31,7 @@ module.exports = function(containers, options) {
 
         var daemons = _.filter(containers, { daemon: true })
         helpers.asyncIterate(daemons, function(container, next) {
-            stop(container, next)
+            stop(container, null, next)
         }, done)
     }
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -17,12 +17,12 @@ module.exports = function(containers, options) {
         ], { stdio: 'inherit' })
     }
 
-    function startDaemons(done) {
+    function startDaemons(startOptions, done) {
         done = done || _.noop
 
         var daemons = _.filter(containers, { daemon: true })
         helpers.asyncIterate(daemons, function(container, next) {
-            start(container, [], { recreate: true }, next)
+            start(container, [], startOptions, next)
         }, done)
     }
 

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -17,7 +17,7 @@ module.exports = function(containers, options, logger) {
                 var container = containers[name]
                 container.daemon = true
 
-                start(container, [], { recreate: true }, function(err) {
+                start(container, [], startOptions, function(err) {
                     if (err) {
                         fail(err)
                     } else {

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -63,7 +63,7 @@ module.exports = function(containers, options, logger) {
                         if (err) {
                             done(err)
                         } else {
-                            run(done)
+                            dockerRun(done)
                         }
                     })
                 })
@@ -83,7 +83,7 @@ module.exports = function(containers, options, logger) {
                             if (isRunning) {
                                 done()
                             } else {
-                                start(done)
+                                dockerStart(done)
                             }
                         })
                     }
@@ -94,17 +94,17 @@ module.exports = function(containers, options, logger) {
             })
         }
 
-        function start(callback) {
+        function dockerStart(callback) {
             var args = ['start', container.name]
-            execDocker(container, args, "Starting", callback)
+            execDockerCmd(container, args, "Starting", callback)
         }
 
-        function run(callback) {
+        function dockerRun(callback) {
             var args = ['run'].concat(runOptions(container, commandArgs))
-            execDocker(container, args, "Running", callback)
+            execDockerCmd(container, args, "Running", callback)
         }
 
-        function execDocker(container, args, action, callback) {
+        function execDockerCmd(container, args, action, callback) {
             logger.info(action + " " + container.name + ", command line: docker " + args.join(' '))
 
             spawn('docker', args, { stdio: 'inherit' }).on('close', function(code) {

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -44,17 +44,17 @@ module.exports = function(containers, options, logger) {
 
         done = done || _.noop
 
-        helpers.checkRunning(container, function(isRunning) {
-            if (isRunning && startOptions.recreate) {
-                stop(container, startContainer)
-            } else if (!isRunning) {
-                startContainer()
+        helpers.checkCreated(container, function(isCreated) {
+            if (isCreated && startOptions.recreate) {
+                stop(container, {removeStopped: true}, createAndStartContainer)
+            } else if (!isCreated) {
+                createAndStartContainer()
             } else {
-                done() // nothing to be done
+                startContainer()
             }
         })
 
-        function startContainer() {
+        function createAndStartContainer() {
             withHooks(container, function(done) {
                 build(container, function(err) {
                     if (err) return done(err)
@@ -73,9 +73,39 @@ module.exports = function(containers, options, logger) {
             })
         }
 
+        function startContainer() {
+            withHooks(container, function(done) {
+                startDeps(container, function(err) {
+                    if (err) {
+                        done(err)
+                    } else {
+                        helpers.checkRunning(container, function(isRunning) {
+                            if (isRunning) {
+                                done()
+                            } else {
+                                start(done)
+                            }
+                        })
+                    }
+                })
+            }, function(err) {
+                process.chdir(originalWorkingDirectory)
+                done(err)
+            })
+        }
+
+        function start(callback) {
+            var args = ['start', container.name]
+            execDocker(container, args, "Starting", callback)
+        }
+
         function run(callback) {
             var args = ['run'].concat(runOptions(container, commandArgs))
-            logger.info("Starting " + container.name + ", command line: docker " + args.join(' '))
+            execDocker(container, args, "Running", callback)
+        }
+
+        function execDocker(container, args, action, callback) {
+            logger.info(action + " " + container.name + ", command line: docker " + args.join(' '))
 
             spawn('docker', args, { stdio: 'inherit' }).on('close', function(code) {
                 if (code !== 0) {

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -1,8 +1,9 @@
 var exec = require('child_process').exec,
+       _ = require('lodash'),
  helpers = require('../helpers')
 
 function rm(container, done) {
-    done = done || _.noop 
+    done = done || _.noop
 
     exec('docker rm ' + container.name, function(err) {
         done()
@@ -10,16 +11,21 @@ function rm(container, done) {
 }
 
 module.exports = function(logger) {
-    return function(container, done) {
-        done = done || _.noop 
+    return function(container, opts, done) {
+        opts = _.defaults(opts || {}, {removeStopped: false})
+        done = done || _.noop
 
-        helpers.checkRunning(container, function(isRunning) {
-            if (!isRunning) {
+        helpers.checkCreated(container, function(isCreated) {
+            if (!isCreated) {
                 done()
             } else {
                 logger.info("Stopping " + container.name)
                 exec('docker stop ' + container.name, function() {
-                    rm(container, done)
+                    if (opts.removeStopped) {
+                        rm(container, done)
+                    } else {
+                        done()
+                    }
                 })
             }
         })

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -28,3 +28,9 @@ module.exports.checkRunning = function(container, callback) {
     })
 }
 
+module.exports.checkCreated = function(container, callback) {
+    exec('docker inspect ' + container.name, function(err) {
+        var isCreated = err ? false : true
+        callback(isCreated)
+    })
+}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,4 +1,6 @@
-var exec = require('child_process').exec
+var exec = require('child_process').exec,
+       _ = require('lodash')
+
 
 module.exports.asyncIterate = function(array, callback, done) {
     function iterate(idx) {
@@ -15,9 +17,14 @@ module.exports.asyncIterate = function(array, callback, done) {
 }
 
 module.exports.checkRunning = function(container, callback) {
-    exec('docker inspect ' + container.name, function(err) {
-        var isRunning = err ? false : true 
-        callback(isRunning)
+    exec('docker inspect ' + container.name, function(err, stdout) {
+        if (err) {
+            callback(false)
+        } else {
+            var info = _.head(JSON.parse(stdout))
+            var isRunning = info && info.State ? !!info.State.Running : false
+            callback(isRunning)
+        }
     })
 }
 

--- a/test/rm-container-test.js
+++ b/test/rm-container-test.js
@@ -1,0 +1,66 @@
+var helpers = require('./helpers'),
+     expect = require('chai').expect,
+      async = require('async'),
+       exec = require('child_process').exec
+
+describe('removing containers', function() {
+    after(helpers.cleanUpTestContainers)
+    var containers = {
+        "daemon1":{
+            "name": "test-daemon1",
+            "image":"ubuntu",
+            "daemon":true,
+            "command":["echo", "hello from daemon1"]
+        },
+
+        "daemon2":{
+            "name": "test-daemon2",
+            "image":"ubuntu",
+            "daemon":true,
+            "command":["echo", "hello from daemon2"]
+        }
+    }
+
+    var commands = helpers.commands(containers)
+
+    before(function(done) {
+        commands.startDaemons({recreate: true}, done)
+    })
+
+    it('stops and removes only the selected container', function(done) {
+        commands.remove(containers.daemon1, function() {
+            containerRunning('test-daemon1', function(running) {
+                expect(running).to.eql(false)
+                containerExists('test-daemon1', function(exists) {
+                    expect(exists).to.eql(false)
+                    containerExists('test-daemon2', function(d2Running) {
+                        expect(d2Running).to.eql(true)
+                        done()
+                    })
+                })
+            })
+        })
+    })
+
+
+    function containerExists(name, callback) {
+        exec('docker inspect ' + name, function(err) {
+            if (err) {
+                callback(false)
+            } else {
+                callback(true)
+            }
+        })
+    }
+
+    function containerRunning(name, callback) {
+        exec('docker inspect ' + name, function(err, stdout) {
+            if (err) {
+                callback(false)
+            } else {
+                console.log(stdout)
+                callback(!!JSON.parse(stdout)[0].State.Running)
+            }
+        })
+    }
+})

--- a/test/start-no-recreate-test.js
+++ b/test/start-no-recreate-test.js
@@ -1,0 +1,37 @@
+var helpers = require('./helpers'),
+    expect = require('chai').expect,
+    exec = require('child_process').exec,
+    _ = require('lodash')
+
+describe('starting a simple container without re-creation', function() {
+    after(helpers.cleanUpTestContainers)
+
+    var container = {
+        "image": "ubuntu",
+        "name": "test-container",
+        "command": ["sh", "-c", "echo foo >> /tmp/_data && cat /tmp/_data"]
+    }
+
+    var commands = require('../lib/commands')(container, { interactive: false })
+
+    it("preserves the container's state", function(done) {
+        start(true, function(out) {
+            expect(out).to.eql("foo\n")
+            commands.stop(container, function() {
+                start(false, function(out) {
+                  expect(out).to.eql("foo\nfoo\nfoo\n")  // third line comes from log reading
+                  done()
+                })
+            })
+        })
+
+        function start(recreate, callback) {
+          commands.start(container, [], {recreate: recreate}, function() {
+            helpers.logsOutput("test-container", function() {
+              helpers.logsOutput("test-container", callback)
+            })
+          })
+        }
+    })
+})
+


### PR DESCRIPTION
Current behaviour of `pig start` and `pig stop` commands differs from Docker's ones. Instead of stopping/starting the container those commands actually remove the container and re-create it from scratch. This behaviour prevents using `pig` for development database management (because data disappears every time when development machine is restarted).

This pull request adds the ability to use existing containers instead of re-creating a new one every time when `pig start` or `pig up` is called:

* `pig stop` no longer removes the stopped container
* `pig start` and `pig up` has CLI option `-R|--no-recreate` which prevents the re-creation if container is already created, e.g.
  * `pig up -R`
  * `pig start -R mongo`
* Added `pig rm CONTAINER` to actually remove the container 